### PR TITLE
Folder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install --save restdocs-to-postman
 ## Command Line Usage
 
 ```shell
-restdocs-to-postman --input generated-snippets --export-format postman --output postman-collection.json
+restdocs-to-postman --input generated-snippets --export-format postman --determine-folder secondLastFolder --output postman-collection.json
 ```
 
 From the given folder, all folders are recursively scanned for `curl-request.adoc` and `curl-request.md` files.
@@ -48,7 +48,7 @@ for an example of a replacement file.
 const converter = require('restdocs-to-postman');
 
 // Convert Spring REST Docs cURL commands to Postman/Insomnia collections
-const folder = './target/generated-snippets';
+const folderToScan = './target/generated-snippets';
 const exportFormat = 'postman';
 const replacements = {
   host: {
@@ -62,7 +62,7 @@ const replacements = {
      }
   ]
 };
-const output = converter.convert({folder, exportFormat, replacements});
+const output = converter.convert({folderToScan, exportFormat, replacements});
 
 // Print the result
 console.log(output);

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install --save restdocs-to-postman
 ## Command Line Usage
 
 ```shell
-restdocs-to-postman --folder generated-snippets --export-format postman --output postman-collection.json
+restdocs-to-postman --input generated-snippets --export-format postman --output postman-collection.json
 ```
 
 From the given folder, all folders are recursively scanned for `curl-request.adoc` and `curl-request.md` files.
@@ -62,7 +62,7 @@ const replacements = {
      }
   ]
 };
-const output = converter.convert(folder, exportFormat, replacements);
+const output = converter.convert({folder, exportFormat, replacements});
 
 // Print the result
 console.log(output);

--- a/index.js
+++ b/index.js
@@ -16,6 +16,6 @@
 'use strict';
 const converter = require('./src/convert');
 
-module.exports.convert = function (folder, exportFormat, replacements) {
-    return converter.convert(folder, exportFormat, replacements);
+module.exports.convert = function (options) {
+    return converter.convert(options);
 };

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -17,9 +17,10 @@
 const fs = require('fs');
 const path = require('path');
 const converter = require('../../index');
+const folderFunctions = require('../folder-functions');
 
-const fixturesPath = path.join(__dirname, './fixtures');
-const snippetsPath = path.join(__dirname, './input-snippets');
+const fixturesPath = path.join(__dirname, 'fixtures');
+const snippetsPath = path.join(__dirname, 'input-snippets');
 
 const exampleReplacements = {
     host: {
@@ -75,5 +76,15 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
             replacements: exampleReplacements
         }));
         expect(actualOutput).toEqual(expectedOutput);
+    });
+
+    it('an Insomnia collection with folders', () => {
+        const expectedOutput = loadFixture('insomnia-with-folders.json');
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'insomnia',
+            folderFn: folderFunctions.secondLastFolder
+        }));
+        expect(actualOutput.resources).toEqual(expectedOutput.resources);
     });
 });

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -41,25 +41,39 @@ const loadFixture = (fileName) => {
 describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('an Insomnia collection', () => {
         const expectedOutput = loadFixture('insomnia.json');
-        const actualOutput = JSON.parse(converter.convert(snippetsPath, 'insomnia'));
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'insomnia'
+        }));
         expect(actualOutput.resources).toEqual(expectedOutput.resources);
     });
 
     it('a Postman collection', () => {
         const expectedOutput = loadFixture('postman.json');
-        const actualOutput = JSON.parse(converter.convert(snippetsPath, 'postman'));
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'postman'
+        }));
         expect(actualOutput).toEqual(expectedOutput);
     });
 
     it('an Insomnia collection with replacements', () => {
         const expectedOutput = loadFixture('insomnia-with-replacements.json');
-        const actualOutput = JSON.parse(converter.convert(snippetsPath, 'insomnia', exampleReplacements));
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'insomnia',
+            replacements: exampleReplacements
+        }));
         expect(actualOutput.resources).toEqual(expectedOutput.resources);
     });
 
     it('a Postman collection with replacements', () => {
         const expectedOutput = loadFixture( 'postman-with-replacements.json');
-        const actualOutput = JSON.parse(converter.convert(snippetsPath, 'postman', exampleReplacements));
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'postman',
+            replacements: exampleReplacements
+        }));
         expect(actualOutput).toEqual(expectedOutput);
     });
 });

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -95,6 +95,28 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
             exportFormat: 'postman',
             folderFn: folderFunctions.secondLastFolder
         }));
+        expect(actualOutput).toEqual(expectedOutput);
+    });
+
+    it('an Insomnia collection with folders and replacements', () => {
+        const expectedOutput = loadFixture('insomnia-with-folders-and-replacements.json');
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'insomnia',
+            folderFn: folderFunctions.secondLastFolder,
+            replacements: exampleReplacements
+        }));
         expect(actualOutput.resources).toEqual(expectedOutput.resources);
+    });
+
+    it('a Postman collection with folders and replacements', () => {
+        const expectedOutput = loadFixture('postman-with-folders-and-replacements.json');
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'postman',
+            folderFn: folderFunctions.secondLastFolder,
+            replacements: exampleReplacements
+        }));
+        expect(actualOutput).toEqual(expectedOutput);
     });
 });

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -43,7 +43,7 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('an Insomnia collection', () => {
         const expectedOutput = loadFixture('insomnia.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'insomnia'
         }));
         expect(actualOutput.resources).toEqual(expectedOutput.resources);
@@ -52,7 +52,7 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('a Postman collection', () => {
         const expectedOutput = loadFixture('postman.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'postman'
         }));
         expect(actualOutput).toEqual(expectedOutput);
@@ -61,7 +61,7 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('an Insomnia collection with replacements', () => {
         const expectedOutput = loadFixture('insomnia-with-replacements.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'insomnia',
             replacements: exampleReplacements
         }));
@@ -71,7 +71,7 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('a Postman collection with replacements', () => {
         const expectedOutput = loadFixture( 'postman-with-replacements.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'postman',
             replacements: exampleReplacements
         }));
@@ -81,9 +81,9 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('an Insomnia collection with folders', () => {
         const expectedOutput = loadFixture('insomnia-with-folders.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'insomnia',
-            folderFn: folderFunctions.secondLastFolder
+            determineFolder: folderFunctions.secondLastFolder
         }));
         expect(actualOutput.resources).toEqual(expectedOutput.resources);
     });
@@ -91,9 +91,9 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('a Postman collection with folders', () => {
         const expectedOutput = loadFixture('postman-with-folders.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'postman',
-            folderFn: folderFunctions.secondLastFolder
+            determineFolder: folderFunctions.secondLastFolder
         }));
         expect(actualOutput).toEqual(expectedOutput);
     });
@@ -101,9 +101,9 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('an Insomnia collection with folders and replacements', () => {
         const expectedOutput = loadFixture('insomnia-with-folders-and-replacements.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'insomnia',
-            folderFn: folderFunctions.secondLastFolder,
+            determineFolder: folderFunctions.secondLastFolder,
             replacements: exampleReplacements
         }));
         expect(actualOutput.resources).toEqual(expectedOutput.resources);
@@ -112,9 +112,9 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
     it('a Postman collection with folders and replacements', () => {
         const expectedOutput = loadFixture('postman-with-folders-and-replacements.json');
         const actualOutput = JSON.parse(converter.convert({
-            folder: snippetsPath,
+            folderToScan: snippetsPath,
             exportFormat: 'postman',
-            folderFn: folderFunctions.secondLastFolder,
+            determineFolder: folderFunctions.secondLastFolder,
             replacements: exampleReplacements
         }));
         expect(actualOutput).toEqual(expectedOutput);

--- a/src/__tests__/convert.test.js
+++ b/src/__tests__/convert.test.js
@@ -87,4 +87,14 @@ describe('Should convert Spring REST Docs cURL snippets to', () => {
         }));
         expect(actualOutput.resources).toEqual(expectedOutput.resources);
     });
+
+    it('a Postman collection with folders', () => {
+        const expectedOutput = loadFixture('postman-with-folders.json');
+        const actualOutput = JSON.parse(converter.convert({
+            folder: snippetsPath,
+            exportFormat: 'postman',
+            folderFn: folderFunctions.secondLastFolder
+        }));
+        expect(actualOutput.resources).toEqual(expectedOutput.resources);
+    });
 });

--- a/src/__tests__/fixtures/insomnia-with-folders-and-replacements.json
+++ b/src/__tests__/fixtures/insomnia-with-folders-and-replacements.json
@@ -1,0 +1,254 @@
+{
+  "_type": "export",
+  "__export_format": 3,
+  "__export_date": "test",
+  "__export_source": "test",
+  "resources": [
+    {
+      "_type": "request_group",
+      "_id": "__FOLDER_1__",
+      "name": "documentation-test",
+      "parentId": "__WORKSPACE_ID__",
+      "metaSortKey": 0
+    },
+    {
+      "_type": "request_group",
+      "_id": "__FOLDER_2__",
+      "name": "item-resource-test",
+      "parentId": "__WORKSPACE_ID__",
+      "metaSortKey": 1
+    },
+    {
+      "parentId": "__FOLDER_1__",
+      "name": "docs",
+      "url": "{{host}}/docs",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_id": "__REQ_1__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_1__",
+      "name": "index",
+      "url": "{{host}}/",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_id": "__REQ_2__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items",
+      "url": "{{host}}/items",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\"description\":\"Hot News\"}"
+      },
+      "method": "POST",
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "name": "Authorization",
+          "value": "{{oauth2Token}}"
+        }
+      ],
+      "authentication": {},
+      "_id": "__REQ_3__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/cloneItem",
+      "url": "{{host}}/items/cloneItem",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{ \"name\": \"xyz\" }"
+      },
+      "method": "POST",
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "authentication": {},
+      "_id": "__REQ_4__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/1",
+      "url": "{{host}}/items/1",
+      "body": {},
+      "method": "DELETE",
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Authorization",
+          "value": "{{oauth2Token}}"
+        }
+      ],
+      "authentication": {},
+      "_id": "__REQ_5__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items",
+      "url": "{{host}}/items",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_id": "__REQ_6__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/1/child-1",
+      "url": "{{host}}/items/1/child-1",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_id": "__REQ_7__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/1",
+      "url": "{{host}}/items/1",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_id": "__REQ_8__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/process",
+      "url": "{{host}}/items/process",
+      "body": {
+        "params": [
+          {
+            "name": "command",
+            "value": "increase",
+            "type": "text"
+          },
+          {
+            "name": "value",
+            "value": "2",
+            "type": "text"
+          }
+        ],
+        "mimeType": "multipart/form-data"
+      },
+      "method": "POST",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_id": "__REQ_9__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/1/process",
+      "url": "{{host}}/items/1/process",
+      "body": {
+        "mimeType": "application/x-www-form-urlencoded",
+        "params": [
+          {
+            "name": "command",
+            "value": "increase"
+          },
+          {
+            "name": "value",
+            "value": "3"
+          }
+        ]
+      },
+      "method": "POST",
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/x-www-form-urlencoded"
+        }
+      ],
+      "authentication": {},
+      "_id": "__REQ_10__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/search",
+      "url": "{{host}}/items/search?desc=main&hint=1",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_id": "__REQ_11__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/1",
+      "url": "{{host}}/items/1",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\"description\":\"Hot News\"}"
+      },
+      "method": "PUT",
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "name": "Authorization",
+          "value": "{{oauth2Token}}"
+        }
+      ],
+      "authentication": {},
+      "_id": "__REQ_12__",
+      "_type": "request"
+    },
+    {
+      "parentId": "__FOLDER_2__",
+      "name": "items/validateMetadata",
+      "url": "{{host}}/items/validateMetadata",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{ \"type\": \"1\", \"tag\": \"myItem\" }"
+      },
+      "method": "POST",
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "authentication": {},
+      "_id": "__REQ_13__",
+      "_type": "request"
+    }
+  ]
+}

--- a/src/__tests__/fixtures/insomnia-with-folders.json
+++ b/src/__tests__/fixtures/insomnia-with-folders.json
@@ -9,14 +9,14 @@
       "_id": "__FOLDER_1__",
       "name": "documentation-test",
       "parentId": "__WORKSPACE_ID__",
-      "metaSortKey": 1
+      "metaSortKey": 0
     },
     {
       "_type": "request_group",
       "_id": "__FOLDER_2__",
       "name": "item-resource-test",
       "parentId": "__WORKSPACE_ID__",
-      "metaSortKey": 2
+      "metaSortKey": 1
     },
     {
       "parentId": "__FOLDER_1__",

--- a/src/__tests__/fixtures/insomnia-with-folders.json
+++ b/src/__tests__/fixtures/insomnia-with-folders.json
@@ -5,7 +5,21 @@
   "__export_source": "test",
   "resources": [
     {
+      "_type": "request_group",
+      "_id": "__FOLDER_1__",
+      "name": "documentation-test",
       "parentId": "__WORKSPACE_ID__",
+      "metaSortKey": 1
+    },
+    {
+      "_type": "request_group",
+      "_id": "__FOLDER_2__",
+      "name": "item-resource-test",
+      "parentId": "__WORKSPACE_ID__",
+      "metaSortKey": 2
+    },
+    {
+      "parentId": "__FOLDER_1__",
       "name": "docs",
       "url": "http://localhost:8080/docs",
       "body": {},
@@ -17,7 +31,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_1__",
       "name": "index",
       "url": "http://localhost:8080/",
       "body": {},
@@ -29,7 +43,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items",
       "url": "http://localhost:8080/items",
       "body": {
@@ -53,7 +67,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/cloneItem",
       "url": "http://localhost:8080/items/cloneItem",
       "body": {
@@ -73,7 +87,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/1",
       "url": "http://localhost:8080/items/1",
       "body": {},
@@ -90,7 +104,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items",
       "url": "http://localhost:8080/items",
       "body": {},
@@ -102,7 +116,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/1/child-1",
       "url": "http://localhost:8080/items/1/child-1",
       "body": {},
@@ -114,7 +128,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/1",
       "url": "http://localhost:8080/items/1",
       "body": {},
@@ -126,7 +140,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/process",
       "url": "http://localhost:8080/items/process",
       "body": {
@@ -152,7 +166,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/1/process",
       "url": "http://localhost:8080/items/1/process",
       "body": {
@@ -181,7 +195,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/search",
       "url": "http://localhost:8080/items/search?desc=main&hint=1",
       "body": {},
@@ -193,7 +207,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/1",
       "url": "http://localhost:8080/items/1",
       "body": {
@@ -217,7 +231,7 @@
       "_type": "request"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "parentId": "__FOLDER_2__",
       "name": "items/validateMetadata",
       "url": "http://localhost:8080/items/validateMetadata",
       "body": {

--- a/src/__tests__/fixtures/insomnia-with-replacements.json
+++ b/src/__tests__/fixtures/insomnia-with-replacements.json
@@ -1,8 +1,8 @@
 {
   "_type": "export",
   "__export_format": 3,
-  "__export_date": "2018-01-10T19:53:47.619Z",
-  "__export_source": "insomnia.importers:v0.1.0",
+  "__export_date": "test",
+  "__export_source": "test",
   "resources": [
     {
       "parentId": "__WORKSPACE_ID__",

--- a/src/__tests__/fixtures/postman-with-folders-and-replacements.json
+++ b/src/__tests__/fixtures/postman-with-folders-and-replacements.json
@@ -1,0 +1,347 @@
+{
+  "info": {
+    "name": "REST Docs to Postman",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "documentation-test",
+      "item": [
+        {
+          "name": "docs",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "{{host}}/docs",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "docs"
+              ]
+            }
+          }
+        },
+        {
+          "name": "index",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "{{host}}/",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "item-resource-test",
+      "item": [
+        {
+          "name": "items",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "{{oauth2Token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"description\":\"Hot News\"}"
+            },
+            "url": {
+              "raw": "{{host}}/items",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/cloneItem",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"xyz\" }"
+            },
+            "url": {
+              "raw": "{{host}}/items/cloneItem",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "cloneItem"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "{{oauth2Token}}"
+              }
+            ],
+            "body": null,
+            "url": {
+              "raw": "{{host}}/items/1",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "{{host}}/items",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1/child-1",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "{{host}}/items/1/child-1",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "1",
+                "child-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "{{host}}/items/1",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/process",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "command",
+                  "value": "increase"
+                },
+                {
+                  "key": "value",
+                  "value": "2"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{host}}/items/process",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "process"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1/process",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "command",
+                  "value": "increase"
+                },
+                {
+                  "key": "value",
+                  "value": "3"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{host}}/items/1/process",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "1",
+                "process"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/search",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "{{host}}/items/search?desc=main&hint=1",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "desc",
+                  "value": "main"
+                },
+                {
+                  "key": "hint",
+                  "value": "1"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "{{oauth2Token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"description\":\"Hot News\"}"
+            },
+            "url": {
+              "raw": "{{host}}/items/1",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/validateMetadata",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"type\": \"1\", \"tag\": \"myItem\" }"
+            },
+            "url": {
+              "raw": "{{host}}/items/validateMetadata",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "",
+                "items",
+                "validateMetadata"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/__tests__/fixtures/postman-with-folders.json
+++ b/src/__tests__/fixtures/postman-with-folders.json
@@ -1,0 +1,347 @@
+{
+  "info": {
+    "name": "REST Docs to Postman",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "documentation-test",
+      "item": [
+        {
+          "name": "docs",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "http://localhost:8080/docs",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "docs"
+              ]
+            }
+          }
+        },
+        {
+          "name": "index",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "http://localhost:8080/",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "item-resource-test",
+      "item": [
+        {
+          "name": "items",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer 8114cde8-26dd-4c61-b601-29f945b67d25"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"description\":\"Hot News\"}"
+            },
+            "url": {
+              "raw": "http://localhost:8080/items",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/cloneItem",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"xyz\" }"
+            },
+            "url": {
+              "raw": "http://localhost:8080/items/cloneItem",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "cloneItem"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer 8114cde8-26dd-4c61-b601-29f945b67d25"
+              }
+            ],
+            "body": null,
+            "url": {
+              "raw": "http://localhost:8080/items/1",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "http://localhost:8080/items",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1/child-1",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "http://localhost:8080/items/1/child-1",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "1",
+                "child-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "http://localhost:8080/items/1",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/process",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "command",
+                  "value": "increase"
+                },
+                {
+                  "key": "value",
+                  "value": "2"
+                }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8080/items/process",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "process"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1/process",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "command",
+                  "value": "increase"
+                },
+                {
+                  "key": "value",
+                  "value": "3"
+                }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8080/items/1/process",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "1",
+                "process"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/search",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "body": null,
+            "url": {
+              "raw": "http://localhost:8080/items/search?desc=main&hint=1",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "desc",
+                  "value": "main"
+                },
+                {
+                  "key": "hint",
+                  "value": "1"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/1",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer 8114cde8-26dd-4c61-b601-29f945b67d25"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"description\":\"Hot News\"}"
+            },
+            "url": {
+              "raw": "http://localhost:8080/items/1",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "items/validateMetadata",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"type\": \"1\", \"tag\": \"myItem\" }"
+            },
+            "url": {
+              "raw": "http://localhost:8080/items/validateMetadata",
+              "host": [
+                "http://localhost:8080"
+              ],
+              "path": [
+                "",
+                "items",
+                "validateMetadata"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/__tests__/folder-functions.test.js
+++ b/src/__tests__/folder-functions.test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+const path = require('path');
+const folderFunctions = require('../folder-functions');
+
+// This function ensures that the tests work across systems.
+const toSystemPath = (filePath) => {
+    return filePath.replace('/', path.sep);
+};
+
+describe('secondLastFolder should convert a given path to', () => {
+    it('to the second last folder if sufficient many folders are given', () => {
+        const givenPath = toSystemPath('generated-snippets/items/get/curl-request.adoc');
+        const actual = folderFunctions.secondLastFolder(givenPath);
+        expect(actual).toEqual('items');
+    });
+
+    it('to null if insufficient many folders are given', () => {
+        const givenPath = toSystemPath('get/curl-request.adoc');
+        const actual = folderFunctions.secondLastFolder(givenPath);
+        expect(actual).toBeNull();
+    });
+});

--- a/src/__tests__/folder-functions.test.js
+++ b/src/__tests__/folder-functions.test.js
@@ -35,3 +35,15 @@ describe('secondLastFolder should convert a given path to', () => {
         expect(actual).toBeNull();
     });
 });
+
+describe('nameToFunction should convert', () => {
+    it('the known function secondLastFolder', () => {
+        const actual = folderFunctions.nameToFunction('secondLastFolder');
+        expect(actual).toEqual(folderFunctions.secondLastFolder);
+    });
+
+    it('an unknown name to an error', () => {
+        const actual = () => folderFunctions.nameToFunction('unknownFunction');
+        expect(actual).toThrow('Unknown folder function: unknownFunction');
+    });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -29,7 +29,7 @@ module.exports.go = function () {
         .option('-e, --export-format [format]', 'export format', 'postman')
         .option('-o, --output [file]', 'output file')
         .option('-r, --replacements [file]', 'optional JSON file with replacements')
-        .option('-f, --folder-function [function name]', 'optional function to structure requests into folders')
+        .option('-f, --determine-folder [function name]', 'optional function to structure requests into folders')
         .parse(process.argv);
 
     let replacements;

--- a/src/cli.js
+++ b/src/cli.js
@@ -38,10 +38,10 @@ module.exports.go = function () {
     }
     // Conversion
     const result = converter.convert({
-        folder: program.input,
+        folderToScan: program.input,
         exportFormat: program.exportFormat,
         replacements: replacements,
-        folderFn: folderFunctions.nameToFunction(program.folderFunction)
+        determineFolder: folderFunctions.nameToFunction(program.folderFunction)
     });
     // Output/write result
     if (program.output) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,16 +18,18 @@ const fs = require('fs');
 const path = require('path');
 const program = require('commander');
 const converter = require('./convert');
+const folderFunctions = require('./folder-functions');
 const {version} = require('../package.json');
 
 module.exports.go = function () {
 
     program
         .version(version, '-v, --version')
-        .option('-f, --folder [folder]', 'folder to recursively scan for REST Docs curl-request.adoc/md files', '.')
+        .option('-i, --input [folder]', 'folder to recursively scan for REST Docs curl-request.adoc/md files', '.')
         .option('-e, --export-format [format]', 'export format', 'postman')
         .option('-o, --output [file]', 'output file')
         .option('-r, --replacements [file]', 'optional JSON file with replacements')
+        .option('-f, --folder-function [function name]', 'optional function to structure requests into folders')
         .parse(process.argv);
 
     let replacements;
@@ -36,14 +38,19 @@ module.exports.go = function () {
     }
     // Conversion
     const result = converter.convert({
-        folder: program.folder,
+        folder: program.input,
         exportFormat: program.exportFormat,
-        replacements: replacements
+        replacements: replacements,
+        folderFn: folderFunctions.nameToFunction(program.folderFunction)
     });
     // Output/write result
     if (program.output) {
         const fullOutputPath = path.resolve(program.output);
-        fs.writeFileSync(fullOutputPath, result);
+        if (fullOutputPath) {
+            fs.writeFileSync(fullOutputPath, result);
+        } else {
+            console.log('No cURL commands were found.');
+        }
     } else {
         console.log(result);
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,7 +35,11 @@ module.exports.go = function () {
         replacements = JSON.parse(fs.readFileSync(program.replacements, 'utf8'));
     }
     // Conversion
-    const result = converter.convert(program.folder, program.exportFormat, replacements);
+    const result = converter.convert({
+        folder: program.folder,
+        exportFormat: program.exportFormat,
+        replacements: replacements
+    });
     // Output/write result
     if (program.output) {
         const fullOutputPath = path.resolve(program.output);

--- a/src/convert.js
+++ b/src/convert.js
@@ -66,7 +66,11 @@ module.exports.convert = (folder, exportFormat, replacements) => {
         }
     });
     const insomniaCollection = curlToInsomnia.toInsomniaCollection(allCurls);
-    insomniaCollection.resources.forEach(i => shortenName(i));
+    insomniaCollection.resources.forEach(i => {
+        if (i._type === 'request') {
+            shortenName(i);
+        }
+    });
 
     if (exportFormat === 'insomnia') {
         insomniaReplacements.performInsomniaReplacements(insomniaCollection, replacements);

--- a/src/convert.js
+++ b/src/convert.js
@@ -48,7 +48,8 @@ const shortenName = (insomniaItem) => {
     }
 };
 
-module.exports.convert = (folder, exportFormat, replacements) => {
+module.exports.convert = (options) => {
+    let {folder, exportFormat, replacements, folderFn} = options;
     const results = utils.traverseFilesSync(folder);
     if (!results) {
         return;
@@ -65,7 +66,7 @@ module.exports.convert = (folder, exportFormat, replacements) => {
             }
         }
     });
-    const insomniaCollection = curlToInsomnia.toInsomniaCollection(allCurls);
+    const insomniaCollection = curlToInsomnia.toInsomniaCollection(folderFn, allCurls);
     insomniaCollection.resources.forEach(i => {
         if (i._type === 'request') {
             shortenName(i);

--- a/src/convert.js
+++ b/src/convert.js
@@ -53,12 +53,15 @@ module.exports.convert = (folder, exportFormat, replacements) => {
     if (!results) {
         return;
     }
-    let allCurls = '';
-    results.forEach(r => {
-        if (r.endsWith('curl-request.adoc') || r.endsWith('curl-request.md')) {
-            const extractedCurl = curlFromRestDocsFile(r);
+    let allCurls = [];
+    results.forEach(filePath => {
+        if (filePath.endsWith('curl-request.adoc') || filePath.endsWith('curl-request.md')) {
+            const extractedCurl = curlFromRestDocsFile(filePath);
             if (extractedCurl !== null) {
-                allCurls += extractedCurl + ';';
+                allCurls.push({
+                    path: filePath,
+                    curl: extractedCurl
+                });
             }
         }
     });

--- a/src/convert.js
+++ b/src/convert.js
@@ -48,11 +48,16 @@ const shortenName = (insomniaItem) => {
     }
 };
 
+/**
+ *
+ * @param {{folder: string, exportFormat: string, replacements: ?Object, folderFn: ?function}} options
+ * @return {?string}
+ */
 module.exports.convert = (options) => {
     let {folder, exportFormat, replacements, folderFn} = options;
     const results = utils.traverseFilesSync(folder);
     if (!results) {
-        return;
+        return null;
     }
     let allCurls = [];
     results.forEach(filePath => {

--- a/src/convert.js
+++ b/src/convert.js
@@ -50,12 +50,12 @@ const shortenName = (insomniaItem) => {
 
 /**
  *
- * @param {{folder: string, exportFormat: string, replacements: ?Object, folderFn: ?function}} options
+ * @param {{folderToScan: string, exportFormat: string, replacements: ?Object, determineFolder: ?function}} options
  * @return {?string}
  */
 module.exports.convert = (options) => {
-    let {folder, exportFormat, replacements, folderFn} = options;
-    const results = utils.traverseFilesSync(folder);
+    let {folderToScan, exportFormat, replacements, determineFolder} = options;
+    const results = utils.traverseFilesSync(folderToScan);
     if (!results) {
         return null;
     }
@@ -71,7 +71,7 @@ module.exports.convert = (options) => {
             }
         }
     });
-    const insomniaCollection = curlToInsomnia.toInsomniaCollection(folderFn, allCurls);
+    const insomniaCollection = curlToInsomnia.toInsomniaCollection(determineFolder, allCurls);
     insomniaCollection.resources.forEach(i => {
         if (i._type === 'request') {
             shortenName(i);

--- a/src/curl-to-insomnia3.js
+++ b/src/curl-to-insomnia3.js
@@ -54,14 +54,16 @@ const addFolders = (folderFn, resourceWrappers) => {
                     _type: 'request_group',
                     _id: `__FOLDER_${folderCount}__`,
                     name: folder,
-                    parentId: '__WORKSPACE_ID__',
-                    metaSortKey: folderCount
+                    parentId: '__WORKSPACE_ID__'
                 });
                 resourceWrapper.resource.parentId = folderId;
                 folderNameToId[folder] = folderId;
             }
         }
     });
+    folderResources
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .forEach((resource, index) => resource.metaSortKey = index);
     return folderResources;
 };
 

--- a/src/curl-to-insomnia3.js
+++ b/src/curl-to-insomnia3.js
@@ -3,11 +3,27 @@
  */
 'use strict';
 const importers = require('insomnia-importers');
+const {version} = require('../package.json');
 
 /**
  *
  * @param curlCommands cURL commands separated by semicolons
  */
 module.exports.toInsomniaCollection = (curlCommands) => {
-    return importers.convert(curlCommands).data;
+    const resourceWrappers = curlCommands.map(c => {
+        return {
+            path: c.path,
+            resource: importers.convert(c.curl).data.resources[0]
+        }
+    });
+    return {
+        _type: 'export',
+        __export_format: 3,
+        __export_date: new Date().toISOString(),
+        __export_source: 'restdocs-to-postman:v' + version,
+        resources: resourceWrappers.map((resourceWrapper, index) => {
+            resourceWrapper.resource._id = `__REQ_${index + 1}__`;
+            return resourceWrapper.resource;
+        })
+    };
 };

--- a/src/curl-to-insomnia3.js
+++ b/src/curl-to-insomnia3.js
@@ -1,14 +1,40 @@
 /*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
  * Converts cURL commands to Insomnia export format v3
  */
 'use strict';
 const importers = require('insomnia-importers');
 const {version} = require('../package.json');
 
+/**
+ * @param {function(path: string, url: string): ?string} folderFn
+ * @param {{path: string, resource: Object}} resourceWrapper
+ * @return {?string} optional folder name
+ */
 const toFolder = (folderFn, resourceWrapper) => {
     return folderFn(resourceWrapper.path, resourceWrapper.resource.url);
 };
 
+/**
+ * @param {function(path: string, url: string): ?string} folderFn
+ * @param {Array<{path: string, resource: Object}>} resourceWrappers
+ * @return {Array<Object>} Array of Insomnia resources representing all folders
+ */
 const addFolders = (folderFn, resourceWrappers) => {
     const folderResources = [];
     if (!folderFn) {
@@ -40,8 +66,8 @@ const addFolders = (folderFn, resourceWrappers) => {
 };
 
 /**
- *
- * @param curlCommands cURL commands separated by semicolons
+ * @param {function(path: string, url: string): ?string} folderFn
+ * @param {Array<{path: string, curl: string}>} curlCommands
  */
 module.exports.toInsomniaCollection = (folderFn, curlCommands) => {
     const resourceWrappers = curlCommands.map(c => {

--- a/src/curl-to-insomnia3.js
+++ b/src/curl-to-insomnia3.js
@@ -43,7 +43,7 @@ const addFolders = (folderFn, resourceWrappers) => {
  *
  * @param curlCommands cURL commands separated by semicolons
  */
-module.exports.toInsomniaCollection = (curlCommands) => {
+module.exports.toInsomniaCollection = (folderFn, curlCommands) => {
     const resourceWrappers = curlCommands.map(c => {
         return {
             path: c.path,
@@ -51,7 +51,6 @@ module.exports.toInsomniaCollection = (curlCommands) => {
         }
     });
 
-    const folderFn = null;
     const folderResources = addFolders(folderFn, resourceWrappers);
 
     const requestResources = resourceWrappers.map((resourceWrapper, index) => {

--- a/src/curl-to-insomnia3.js
+++ b/src/curl-to-insomnia3.js
@@ -5,6 +5,40 @@
 const importers = require('insomnia-importers');
 const {version} = require('../package.json');
 
+const toFolder = (folderFn, resourceWrapper) => {
+    return folderFn(resourceWrapper.path, resourceWrapper.resource.url);
+};
+
+const addFolders = (folderFn, resourceWrappers) => {
+    const folderResources = [];
+    if (!folderFn) {
+        return folderResources;
+    }
+    let folderCount = 0;
+    const folderNameToId = {};
+    resourceWrappers.forEach(resourceWrapper => {
+        const folder = toFolder(folderFn, resourceWrapper);
+        if (folder) {
+            if (folderNameToId[folder]) {
+                resourceWrapper.resource.parentId = folderNameToId[folder];
+            } else {
+                folderCount++;
+                const folderId = `__FOLDER_${folderCount}__`;
+                folderResources.push({
+                    _type: 'request_group',
+                    _id: `__FOLDER_${folderCount}__`,
+                    name: folder,
+                    parentId: '__WORKSPACE_ID__',
+                    metaSortKey: folderCount
+                });
+                resourceWrapper.resource.parentId = folderId;
+                folderNameToId[folder] = folderId;
+            }
+        }
+    });
+    return folderResources;
+};
+
 /**
  *
  * @param curlCommands cURL commands separated by semicolons
@@ -16,14 +50,20 @@ module.exports.toInsomniaCollection = (curlCommands) => {
             resource: importers.convert(c.curl).data.resources[0]
         }
     });
+
+    const folderFn = null;
+    const folderResources = addFolders(folderFn, resourceWrappers);
+
+    const requestResources = resourceWrappers.map((resourceWrapper, index) => {
+        resourceWrapper.resource._id = `__REQ_${index + 1}__`;
+        return resourceWrapper.resource;
+    });
+
     return {
         _type: 'export',
         __export_format: 3,
         __export_date: new Date().toISOString(),
         __export_source: 'restdocs-to-postman:v' + version,
-        resources: resourceWrappers.map((resourceWrapper, index) => {
-            resourceWrapper.resource._id = `__REQ_${index + 1}__`;
-            return resourceWrapper.resource;
-        })
+        resources: folderResources.concat(requestResources)
     };
 };

--- a/src/curl-to-insomnia3.js
+++ b/src/curl-to-insomnia3.js
@@ -22,28 +22,28 @@ const importers = require('insomnia-importers');
 const {version} = require('../package.json');
 
 /**
- * @param {function(path: string, url: string): ?string} folderFn
+ * @param {function(path: string, url: string): ?string} determineFolder
  * @param {{path: string, resource: Object}} resourceWrapper
  * @return {?string} optional folder name
  */
-const toFolder = (folderFn, resourceWrapper) => {
-    return folderFn(resourceWrapper.path, resourceWrapper.resource.url);
+const toFolder = (determineFolder, resourceWrapper) => {
+    return determineFolder(resourceWrapper.path, resourceWrapper.resource.url);
 };
 
 /**
- * @param {function(path: string, url: string): ?string} folderFn
+ * @param {function(path: string, url: string): ?string} determineFolder
  * @param {Array<{path: string, resource: Object}>} resourceWrappers
  * @return {Array<Object>} Array of Insomnia resources representing all folders
  */
-const addFolders = (folderFn, resourceWrappers) => {
+const addFolders = (determineFolder, resourceWrappers) => {
     const folderResources = [];
-    if (!folderFn) {
+    if (!determineFolder) {
         return folderResources;
     }
     let folderCount = 0;
     const folderNameToId = {};
     resourceWrappers.forEach(resourceWrapper => {
-        const folder = toFolder(folderFn, resourceWrapper);
+        const folder = toFolder(determineFolder, resourceWrapper);
         if (folder) {
             if (folderNameToId[folder]) {
                 resourceWrapper.resource.parentId = folderNameToId[folder];
@@ -68,10 +68,10 @@ const addFolders = (folderFn, resourceWrappers) => {
 };
 
 /**
- * @param {function(path: string, url: string): ?string} folderFn
+ * @param {function(path: string, url: string): ?string} determineFolder
  * @param {Array<{path: string, curl: string}>} curlCommands
  */
-module.exports.toInsomniaCollection = (folderFn, curlCommands) => {
+module.exports.toInsomniaCollection = (determineFolder, curlCommands) => {
     const resourceWrappers = curlCommands.map(c => {
         return {
             path: c.path,
@@ -79,7 +79,7 @@ module.exports.toInsomniaCollection = (folderFn, curlCommands) => {
         }
     });
 
-    const folderResources = addFolders(folderFn, resourceWrappers);
+    const folderResources = addFolders(determineFolder, resourceWrappers);
 
     const requestResources = resourceWrappers.map((resourceWrapper, index) => {
         resourceWrapper.resource._id = `__REQ_${index + 1}__`;

--- a/src/folder-functions.js
+++ b/src/folder-functions.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const path = require('path');
+
+module.exports.secondLastFolder = (filePath, url) => {
+    const parts = filePath.split(path.sep);
+    if (parts.length >= 3) {
+        return parts[parts.length - 3];
+    } else {
+        return null;
+    }
+};

--- a/src/folder-functions.js
+++ b/src/folder-functions.js
@@ -23,3 +23,19 @@ module.exports.secondLastFolder = (filePath, url) => {
         return null;
     }
 };
+
+/**
+ * @param {?string} name
+ * @return {?function}
+ */
+module.exports.nameToFunction = (name) => {
+    if (!name) {
+        return null;
+    }
+    switch (name) {
+        case 'secondLastFolder':
+            return module.exports.secondLastFolder;
+        default:
+            throw new Error('Unknown folder function: ' + name);
+    }
+};

--- a/src/insomnia-replacements.js
+++ b/src/insomnia-replacements.js
@@ -3,6 +3,9 @@ const utils = require('./utils');
 
 const replaceHeaders = (insomniaCollection, headerReplacements) => {
     insomniaCollection.resources.forEach(insomniaResource => {
+        if (insomniaResource._type !== 'request') {
+            return;
+        }
         insomniaResource.headers.forEach(insomniaHeader => {
             headerReplacements.forEach(replacementHeader => {
                 // HTTP header names are case insensitive
@@ -16,7 +19,9 @@ const replaceHeaders = (insomniaCollection, headerReplacements) => {
 
 const replaceHost = (insomniaCollection, hostReplacement) => {
     insomniaCollection.resources.forEach(insomniaResource => {
-        insomniaResource.url = insomniaResource.url.replace(hostReplacement.before, hostReplacement.after);
+        if (insomniaResource._type === 'request') {
+            insomniaResource.url = insomniaResource.url.replace(hostReplacement.before, hostReplacement.after);
+        }
     });
 };
 

--- a/src/insomnia-replacements.js
+++ b/src/insomnia-replacements.js
@@ -16,28 +16,31 @@
 'use strict';
 const utils = require('./utils');
 
+const isRequest = (insomniaResource) => {
+    return insomniaResource._type === 'request';
+};
+
 const replaceHeaders = (insomniaCollection, headerReplacements) => {
-    insomniaCollection.resources.forEach(insomniaResource => {
-        if (insomniaResource._type !== 'request') {
-            return;
-        }
-        insomniaResource.headers.forEach(insomniaHeader => {
-            headerReplacements.forEach(replacementHeader => {
-                // HTTP header names are case insensitive
-                if (utils.caseInsensitiveEquals(insomniaHeader.name, replacementHeader.name)) {
-                    insomniaHeader.value = replacementHeader.newValue;
-                }
+    insomniaCollection.resources
+        .filter(isRequest)
+        .forEach(insomniaResource => {
+            insomniaResource.headers.forEach(insomniaHeader => {
+                headerReplacements.forEach(replacementHeader => {
+                    // HTTP header names are case insensitive
+                    if (utils.caseInsensitiveEquals(insomniaHeader.name, replacementHeader.name)) {
+                        insomniaHeader.value = replacementHeader.newValue;
+                    }
+                });
             });
         });
-    });
 };
 
 const replaceHost = (insomniaCollection, hostReplacement) => {
-    insomniaCollection.resources.forEach(insomniaResource => {
-        if (insomniaResource._type === 'request') {
+    insomniaCollection.resources
+        .filter(isRequest)
+        .forEach(insomniaResource => {
             insomniaResource.url = insomniaResource.url.replace(hostReplacement.before, hostReplacement.after);
-        }
-    });
+        });
 };
 
 module.exports.performInsomniaReplacements = (insomniaCollection, replacements) => {

--- a/src/insomnia-replacements.js
+++ b/src/insomnia-replacements.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
 const utils = require('./utils');
 

--- a/src/insomnia3-to-postman21.js
+++ b/src/insomnia3-to-postman21.js
@@ -1,4 +1,20 @@
 /*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
  * Converts Insomnia export format v3 to Postman Collection Format v2.1.0
  */
 'use strict';

--- a/src/postman-replacements.js
+++ b/src/postman-replacements.js
@@ -16,24 +16,37 @@
 'use strict';
 const utils = require('./utils');
 
+const isRequest = (postmanItem) => {
+    // Only folders have sub items.
+    return !postmanItem.item;
+};
+
 const replaceHeaders = (postmanCollection, headerReplacements) => {
     postmanCollection.item.forEach(postmanItem => {
-        postmanItem.request.header.forEach(postmanHeader => {
-            headerReplacements.forEach(replacementHeader => {
-                // HTTP header names are case insensitive
-                if (utils.caseInsensitiveEquals(postmanHeader.key, replacementHeader.name)) {
-                    postmanHeader.value = replacementHeader.newValue;
-                }
+        if (isRequest(postmanItem)) {
+            postmanItem.request.header.forEach(postmanHeader => {
+                headerReplacements.forEach(replacementHeader => {
+                    // HTTP header names are case insensitive
+                    if (utils.caseInsensitiveEquals(postmanHeader.key, replacementHeader.name)) {
+                        postmanHeader.value = replacementHeader.newValue;
+                    }
+                });
             });
-        });
+        } else {
+            replaceHeaders(postmanItem, headerReplacements);
+        }
     });
 };
 
 const replaceHost = (postmanCollection, hostReplacement) => {
     postmanCollection.item.forEach(postmanItem => {
-        const postmanUrl = postmanItem.request.url;
-        postmanUrl.raw = postmanUrl.raw.replace(hostReplacement.before, hostReplacement.after);
-        postmanUrl.host[0] = postmanUrl.host[0].replace(hostReplacement.before, hostReplacement.after);
+        if (isRequest(postmanItem)) {
+            const postmanUrl = postmanItem.request.url;
+            postmanUrl.raw = postmanUrl.raw.replace(hostReplacement.before, hostReplacement.after);
+            postmanUrl.host[0] = postmanUrl.host[0].replace(hostReplacement.before, hostReplacement.after);
+        } else {
+            replaceHost(postmanItem, hostReplacement);
+        }
     });
 };
 

--- a/src/postman-replacements.js
+++ b/src/postman-replacements.js
@@ -17,8 +17,13 @@
 const utils = require('./utils');
 
 const isRequest = (postmanItem) => {
+    // Only requests have a request field.
+    return postmanItem.request;
+};
+
+const isFolder = (postmanItem) => {
     // Only folders have sub items.
-    return !postmanItem.item;
+    return postmanItem.item;
 };
 
 const replaceHeaders = (postmanCollection, headerReplacements) => {
@@ -32,7 +37,7 @@ const replaceHeaders = (postmanCollection, headerReplacements) => {
                     }
                 });
             });
-        } else {
+        } else if (isFolder(postmanItem)) {
             replaceHeaders(postmanItem, headerReplacements);
         }
     });
@@ -44,7 +49,7 @@ const replaceHost = (postmanCollection, hostReplacement) => {
             const postmanUrl = postmanItem.request.url;
             postmanUrl.raw = postmanUrl.raw.replace(hostReplacement.before, hostReplacement.after);
             postmanUrl.host[0] = postmanUrl.host[0].replace(hostReplacement.before, hostReplacement.after);
-        } else {
+        } else if (isFolder(postmanItem)) {
             replaceHost(postmanItem, hostReplacement);
         }
     });

--- a/src/postman-replacements.js
+++ b/src/postman-replacements.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
 const utils = require('./utils');
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
Support folders for both Insomnia and Postman. Deriving folders from the file path and/or URL can be customized with a function. One function is included in this PR and should cover the most common case for REST Docs: `secondLastFolder`. This function can also be used via the CLI.

This PR includes breaking changes and will thus go into version 2.0.0 (semver). The are a few other breaking changes planned and once they are in version 2.0.0 will be released.

Closes #5 